### PR TITLE
feat(drupal): add local Drupal DDEV environment

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -5,3 +5,4 @@ node_modules
 *.esm.js
 /drupal
 /drupal-*
+/local-next-drupal

--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,6 @@ yarn-error.log*
 /drupal/web/phpunit.xml
 /drupal/web/sites/default/settings.local.php
 /drupal-*
+
+# Local Drupal instance
+local-next-drupal/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -183,3 +183,34 @@ BREAKING CHANGE:
 Dropped support for Next.js 11 and React 16. Users
 requiring these older versions should stick to v1.6.
 ```
+
+## Local Drupal Environment (Experimental)
+
+Requires [DDEV](https://ddev.readthedocs.io/en/latest/users/install/ddev-installation/)
+
+Create a local instance by running:
+
+```
+yarn ddev:init
+```
+
+This will create a local Drupal instance in local-next-drupal which will be ignored by git.
+
+Destroy the local instance by running:
+
+```
+yarn ddev:destroy
+```
+
+To use this environment with local testing, add the following to the related
+.env file:
+
+```
+DRUPAL_BASE_URL="http://local-next-drupal.ddev.site/"
+DRUPAL_CLIENT_ID="next-drupal"
+DRUPAL_CLIENT_SECRET="next"
+```
+
+### Todo
+
+- Update recipe to use local versions of next drupal composer dependencies rather than packagist versions.

--- a/package.json
+++ b/package.json
@@ -29,7 +29,9 @@
     "test": "yarn workspace next-drupal test",
     "pretest": "yarn format:check && yarn lint",
     "test:e2e": "turbo run test:e2e --parallel",
-    "test:e2e:ci": "turbo run test:e2e:ci --parallel"
+    "test:e2e:ci": "turbo run test:e2e:ci --parallel",
+    "ddev:init": "./scripts/init-drupal.sh",
+    "ddev:destroy": "./scripts/destroy-drupal.sh"
   },
   "devDependencies": {
     "@actions/core": "^1.10.1",

--- a/recipes/next_drupal_base/composer.json
+++ b/recipes/next_drupal_base/composer.json
@@ -1,0 +1,15 @@
+{
+  "name": "drupal/next_drupal_base",
+  "description": "Common dependencies and configuration for all Next Drupal projects.",
+  "type": "drupal-recipe",
+  "license": "GPL-2.0-or-later",
+  "repositories": [
+    {
+      "type": "composer",
+      "url": "https://packages.drupal.org/8"
+    }
+  ],
+  "require": {
+    "drupal/next": "^2.0@beta"
+  }
+}

--- a/recipes/next_drupal_base/recipe.yml
+++ b/recipes/next_drupal_base/recipe.yml
@@ -1,0 +1,6 @@
+name: "Next Drupal Base"
+description: "Common dependencies and configuration for all Next Drupal projects"
+type: "Site"
+
+install:
+  - next

--- a/scripts/destroy-drupal.sh
+++ b/scripts/destroy-drupal.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+# Exit immediately on errors.
+set -e
+
+cd local-next-drupal
+ddev delete -y
+cd ..
+echo "Removing drupal directory..."
+rm -rf local-next-drupal

--- a/scripts/init-drupal.sh
+++ b/scripts/init-drupal.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+# Exit immediately on errors.
+set -e
+
+# Create DDEV project
+mkdir local-next-drupal
+cd local-next-drupal
+ddev config --project-name=local-next-drupal --project-type=drupal10 --php-version=8.3 --docroot=web --create-docroot
+ddev start
+ddev composer create drupal/recommended-project
+
+# Prevent composer scaffolding from overwriting development.services.yml
+ddev composer config --json extra.drupal-scaffold.file-mapping '{"[web-root]/sites/development.services.yml": false}'
+ddev composer config minimum-stability dev
+ddev composer config allow-plugins.ewcomposer/unpack true -n
+# Add repositories
+ddev composer config repositories.unpack vcs https://gitlab.ewdev.ca/yonas.legesse/drupal-recipe-unpack.git
+ddev composer config repositories.recipe path web/recipes/next_drupal_base
+
+# Add recipies
+cp -a ../recipes/. web/recipes
+
+# Add useful composer dependencies
+ddev composer require drush/drush drupal/next_drupal_base ewcomposer/unpack:dev-master
+
+# Install Drupal
+ddev drush site:install demo_umami --account-name=admin --account-pass=admin -y
+
+# Apply recipe
+ddev exec -d /var/www/html/web php core/scripts/drupal recipe recipes/next_drupal_base
+ddev composer unpack drupal/next_drupal_base
+
+# use the one-time link (CTRL/CMD + Click) from the command below to edit your admin account details.
+ddev drush uli
+ddev launch


### PR DESCRIPTION
* Adds scripts to init and destroy a local Drupal instance that will be ignored by vcs.
* Initial scaffolding for a next-drupal recipe. Currently only installs next module.

This pull request is for: (mark with an "x")

- [ ] `examples/*`
- [ ] `modules/next`
- [ ] `packages/next-drupal`
- [ ] `starters/basic-starter`
- [ ] `starters/graphql-starter`
- [ ] `starters/pages-starter`
- [ ] Other

GitHub Issue: #
_Please add a link to the GitHub issue
where this problem is discussed._

- [ ] I need help adding tests. (mark with an "x")
      _Code changes need test coverage. If you don't know
      how to make tests, check this box to ask for help._

## Describe your changes

A clear and concise description of what the request is.

If applicable, add screenshots to help explain your issue.
