### PR TITLE
feat(next-drupal)!: make Subrequests module optional

### DIFF
--- a/packages/next-drupal/src/types/next-drupal.ts
+++ b/packages/next-drupal/src/types/next-drupal.ts
@@ -41,6 +41,16 @@ export type NextDrupalOptions = NextDrupalBaseOptions & {
    * [Documentation](https://next-drupal.org/docs/client/configuration#usedefaultendpoints)
    */
   useDefaultEndpoints?: boolean
+
+  /**
+   * Optionally use the subrequests Drupal module to perform 2 or more JSON:API requests in one fetch operation.
+   *
+   * * **Default value**: `false`
+   * * **Required**: *No*
+   *
+   * [Documentation](https://next-drupal.org/docs/client/configuration#usesubrequests)
+   */
+  useSubrequests?: boolean
 }
 
 export type JsonDeserializer = (


### PR DESCRIPTION
BREAKING CHANGE:
The subrequests Drupal module is not optional and next-drupal will now only perform JSON:API subrequests when the useSubrequests flag is enabled.

Fixes #744

This pull request is for: (mark with an "x")

- [ ] `examples/*`
- [ ] `modules/next`
- [ ] `packages/next-drupal`
- [ ] `starters/basic-starter`
- [ ] `starters/graphql-starter`
- [ ] `starters/pages-starter`
- [ ] Other

GitHub Issue: #
_Please add a link to the GitHub issue
where this problem is discussed._

- [ ] I need help adding tests. (mark with an "x")
      _Code changes need test coverage. If you don't know
      how to make tests, check this box to ask for help._

## Describe your changes

A clear and concise description of what the request is.

If applicable, add screenshots to help explain your issue.
